### PR TITLE
Add basic car simulation and state change messaging

### DIFF
--- a/Components/CarManagerComponent.cs
+++ b/Components/CarManagerComponent.cs
@@ -1,0 +1,102 @@
+using MagicCARpet.Contracts.Messages;
+using MagicCARpet.Contracts.Models;
+using MvvmGen.Events;
+using StereoKit;
+using StereoKit.Framework;
+using System;
+using System.Linq;
+
+namespace MagicCARpet.Components
+{
+    internal class CarManagerComponent : IStepper,
+        IEventSubscriber<StateChangedMessage>
+    {
+        private readonly IEventAggregator _eventAggregator;
+        private Graph _graph;
+        private Node _current;
+        private Node _target;
+        private Vec3 _position;
+        private Model _carModel;
+        private bool _active;
+        private Random _random = new Random();
+        private const float _speed = 0.2f; // meters per second
+
+        public CarManagerComponent(IEventAggregator eventAggregator)
+        {
+            _eventAggregator = eventAggregator;
+        }
+
+        public bool Enabled => true;
+
+        public bool Initialize()
+        {
+            _eventAggregator.RegisterSubscriber(this);
+            _carModel = Model.FromMesh(Mesh.GenerateRoundedCube(Vec3.One * 0.05f, 0.01f), Material.Default);
+            return true;
+        }
+
+        public void Shutdown()
+        {
+            _eventAggregator.UnregisterSubscriber(this);
+        }
+
+        public void Step()
+        {
+            if (!_active || _current == null || _target == null)
+                return;
+
+            var dir = _target.Position - _position;
+            var distanceThisFrame = _speed * Time.Stepf;
+            if (dir.Length() <= distanceThisFrame)
+            {
+                _position = _target.Position;
+                _current = _target;
+                if (_current.Connections.Count > 0)
+                {
+                    _target = _current.Connections[_random.Next(_current.Connections.Count)].Item1;
+                }
+                else
+                {
+                    _active = false;
+                }
+            }
+            else
+            {
+                _position += dir.Normalized * distanceThisFrame;
+            }
+
+            _carModel.Draw(Matrix.TS(_position, Vec3.One * 0.05f));
+        }
+
+        public void OnEvent(StateChangedMessage eventData)
+        {
+            if (eventData.State == States.Running)
+            {
+                _eventAggregator.Publish(new RequestRoadGraphMessage(graph =>
+                {
+                    _graph = graph;
+                    StartCar();
+                }));
+            }
+            else
+            {
+                _active = false;
+            }
+        }
+
+        private void StartCar()
+        {
+            var first = _graph?.Nodes?.FirstOrDefault();
+            if (first == null || first.Connections.Count == 0)
+            {
+                _active = false;
+                return;
+            }
+
+            _current = first;
+            _target = _current.Connections[0].Item1;
+            _position = _current.Position;
+            _active = true;
+        }
+    }
+}

--- a/Components/RoadManagerComponent.cs
+++ b/Components/RoadManagerComponent.cs
@@ -14,7 +14,8 @@ namespace MagicCARpet.Components
     internal class RoadManagerComponent : IStepper,
         IEventSubscriber<AddRoadNodeMessage>,
         IEventSubscriber<CheckRoadNodeTriggeredMessage>,
-        IEventSubscriber<RoadNodeGotTriggeredMessage>
+        IEventSubscriber<RoadNodeGotTriggeredMessage>,
+        IEventSubscriber<RequestRoadGraphMessage>
     {
         private Graph _roadGraph;
         private Model _cube;
@@ -95,6 +96,11 @@ namespace MagicCARpet.Components
         public void OnEvent(RoadNodeGotTriggeredMessage eventData)
         {
             _previousNode = _roadGraph.Nodes.First(n => n.Id == eventData.NodeId);
+        }
+
+        public void OnEvent(RequestRoadGraphMessage eventData)
+        {
+            eventData.ResultCallback(_roadGraph);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -26,9 +26,10 @@ class Program
 		EventAggregator = new EventAggregator();
 
 		//Activate steppers
-		SK.AddStepper(new GestureRecognizerComponent(EventAggregator));
-		SK.AddStepper(new StateSystem(EventAggregator));
-		SK.AddStepper(new RoadManagerComponent(EventAggregator));
+        SK.AddStepper(new GestureRecognizerComponent(EventAggregator));
+        SK.AddStepper(new StateSystem(EventAggregator));
+        SK.AddStepper(new RoadManagerComponent(EventAggregator));
+        SK.AddStepper(new CarManagerComponent(EventAggregator));
 
         // Create assets used by the app
         Pose  cubePose = new Pose(0, 0, -0.5f);

--- a/Projects/MagicCARpet.Contracts/Messages/RequestRoadGraphMessage.cs
+++ b/Projects/MagicCARpet.Contracts/Messages/RequestRoadGraphMessage.cs
@@ -1,0 +1,7 @@
+using System;
+using MagicCARpet.Contracts.Models;
+
+namespace MagicCARpet.Contracts.Messages
+{
+    public record RequestRoadGraphMessage(Action<Graph> ResultCallback);
+}

--- a/Projects/MagicCARpet.Contracts/Messages/StateChangedMessage.cs
+++ b/Projects/MagicCARpet.Contracts/Messages/StateChangedMessage.cs
@@ -1,0 +1,6 @@
+using MagicCARpet.Contracts.Models;
+
+namespace MagicCARpet.Contracts.Messages
+{
+    public record StateChangedMessage(States State);
+}

--- a/Projects/MagicCARpet.Contracts/Models/States.cs
+++ b/Projects/MagicCARpet.Contracts/Models/States.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace MagicCARpet.Contracts.Models
+{
+    public enum States
+    {
+        DrawingRoads,
+        Running
+    }
+}

--- a/Systems/StateSystem.cs
+++ b/Systems/StateSystem.cs
@@ -1,20 +1,11 @@
-﻿using MagicCARpet.Contracts.Messages;
+using MagicCARpet.Contracts.Messages;
+using MagicCARpet.Contracts.Models;
 using MvvmGen.Events;
+using StereoKit;
 using StereoKit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MagicCARpet.Systems
 {
-    public enum States
-    {
-        DrawingRoads,
-        Running
-    }
-
     internal class StateSystem : IStepper, IEventSubscriber<PinchHappenedMessage>
     {
         private readonly IEventAggregator _eventAggregator;
@@ -30,12 +21,13 @@ namespace MagicCARpet.Systems
         public bool Initialize()
         {
             _eventAggregator.RegisterSubscriber(this);
+            _eventAggregator.Publish(new StateChangedMessage(_currentState));
             return true;
         }
 
         public void OnEvent(PinchHappenedMessage eventData)
         {
-            if(_currentState == States.DrawingRoads)
+            if (_currentState == States.DrawingRoads)
             {
                 bool gotTriggered = false;
                 //Check if the pinch happened on a road node
@@ -60,6 +52,12 @@ namespace MagicCARpet.Systems
 
         public void Step()
         {
+            if (Input.Key(Key.Space).IsJustActive())
+            {
+                var newState = _currentState == States.DrawingRoads ? States.Running : States.DrawingRoads;
+                _currentState = newState;
+                _eventAggregator.Publish(new StateChangedMessage(newState));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Share application state via new `States` enum and `StateChangedMessage`
- Allow toggling between road drawing and running modes with the space key
- Add a `CarManagerComponent` that requests the road graph and moves a small car along connections

## Testing
- `dotnet build MagicCARpet.csproj` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b897ce8e3c832687188766a04d5fae